### PR TITLE
Add guide for annotations in cedar terraform  provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To generate or update documentation, run `go generate`.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-_Note:_ Acceptance tests create real resources, and often cost money to run.
+*Note:* Acceptance tests create real resources, and often cost money to run.
 
 ```shell
 make testacc

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This provider exposes a Terraform Data Source for authoring [Cedar](https://ceda
 data "cedar_policyset" "example" {
   policy {
     effect = "permit"
+
     annotation {
       name = "advice"
       value = "Allow admins to read public resources unless owned by Alice"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This provider exposes a Terraform Data Source for authoring [Cedar](https://ceda
 data "cedar_policyset" "example" {
   policy {
     effect = "permit"
+    annotation {
+      name = "advice"
+      value = "Allow admins to read public resources unless owned by Alice"
+    }
 
     principal_in = {
       type = "Group"
@@ -30,6 +34,7 @@ data "cedar_policyset" "example" {
 The `data.cedar_policyset.example.text` output will be:
 
 ```
+@advice("Allow admins to read public resources unless owned by Alice")
 permit (
     principal in Group::"admins",
     action == Action::"Read",
@@ -57,7 +62,7 @@ To generate or update documentation, run `go generate`.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+_Note:_ Acceptance tests create real resources, and often cost money to run.
 
 ```shell
 make testacc

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,10 +10,6 @@ This provider exposes a Terraform Data Source for authoring [Cedar](https://ceda
 data "cedar_policyset" "example" {
   policy {
     effect = "permit"
-    annotation {
-      name = "advice"
-      value = "Allow admins to read public resources unless owned by Alice"
-    }
 
     principal_in = {
       type = "Group"
@@ -38,7 +34,6 @@ data "cedar_policyset" "example" {
 The `data.cedar_policyset.example.text` output will be:
 
 ```
-@advice("Allow admins to read public resources unless owned by Alice")
 permit (
     principal in Group::"admins",
     action == Action::"Read",

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@ This provider exposes a Terraform Data Source for authoring [Cedar](https://ceda
 data "cedar_policyset" "example" {
   policy {
     effect = "permit"
+    annotation {
+      name = "advice"
+      value = "Allow admins to read public resources unless owned by Alice"
+    }
 
     principal_in = {
       type = "Group"
@@ -34,6 +38,7 @@ data "cedar_policyset" "example" {
 The `data.cedar_policyset.example.text` output will be:
 
 ```
+@advice("Allow admins to read public resources unless owned by Alice")
 permit (
     principal in Group::"admins",
     action == Action::"Read",

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,11 @@ data "cedar_policyset" "example" {
   policy {
     effect = "permit"
 
+    annotation {
+      name = "advice"
+      value = "Allow admins to read public resources unless owned by Alice"
+    }
+
     principal_in = {
       type = "Group"
       id   = "admins"
@@ -34,6 +39,7 @@ data "cedar_policyset" "example" {
 The `data.cedar_policyset.example.text` output will be:
 
 ```
+@advice("Allow admins to read public resources unless owned by Alice")
 permit (
     principal in Group::"admins",
     action == Action::"Read",

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -11,6 +11,11 @@ data "cedar_policyset" "example" {
   policy {
     effect = "permit"
 
+    annotation {
+      name = "advice"
+      value = "Allow admins to read public resources unless owned by Alice"
+    }
+
     principal_in = {
       type = "Group"
       id   = "admins"
@@ -34,6 +39,7 @@ data "cedar_policyset" "example" {
 The `data.cedar_policyset.example.text` output will be:
 
 ```
+@advice("Allow admins to read public resources unless owned by Alice")
 permit (
     principal in Group::"admins",
     action == Action::"Read",


### PR DESCRIPTION
Tested that output was correct using terraform plan:

```
Changes to Outputs:
  + policy_text = <<-EOT
        @advice("Allow admins to read public resources unless owned by Alice")
        permit (
                principal in Group::"admins",
                action == Action::"Read",
                resource
        )
        when {
                resource.is_public
        }
        unless {
                resource.owner == User::"alice"
        };
    EOT
 ```